### PR TITLE
Fixed TypeScript Error - Fixes #24

### DIFF
--- a/pdf-img-convert.d.ts
+++ b/pdf-img-convert.d.ts
@@ -12,4 +12,4 @@ declare function convert (
   }
 ): Promise<string[]|Uint8Array[]>
 
-export = { convert }
+export {convert}


### PR DESCRIPTION
Modified export in pdf-img-convert.d.ts so that it wouldn't give the error message "The expression of an export assignment must be an identifier or qualified name in an ambient context". Fixes https://github.com/ol-th/pdf-img-convert.js/issues/24