### PR TITLE
Enable setting isEvalSupported parameter

### DIFF
--- a/pdf-img-convert.d.ts
+++ b/pdf-img-convert.d.ts
@@ -11,6 +11,8 @@ declare function convert (
     base64?: boolean
     /** Viewport scale as ratio */
     scale?: number
+    /** Controls the `isEvalSupported` parameter of `pdf-js`. Defaults to `true`. */
+    isEvalSupported?: boolean
   }
 ): Promise<string[]|Uint8Array[]>
 

--- a/pdf-img-convert.js
+++ b/pdf-img-convert.js
@@ -97,7 +97,12 @@ module.exports.convert = async function (pdf, conversion_config = {}) {
   // the images (indexed like array[page][pixel])
 
   var outputPages = [];
-  var loadingTask = pdfjs.getDocument({data: pdfData, disableFontFace: true, verbosity: 0});
+  var loadingTask = pdfjs.getDocument({
+    data: pdfData,
+    disableFontFace: true,
+    verbosity: 0,
+    isEvalSupported: conversion_config.isEvalSupported
+  });
 
   var pdfDocument = await loadingTask.promise
 


### PR DESCRIPTION
As evidenced by the [recent vulnerability found in pdf.js](https://github.com/mozilla/pdf.js/security/advisories/GHSA-wgrm-67xf-hhpq), arbitrary string execution in JS is always a potential danger, no matter how many precautions are taken to prevent arbitrary code execution.

This PR allows setting the `isEvalSupported` to `false` so this can be disabled while parsing the PDF.

# Important note!

The default value in this PR is `true` (as is currently the case). Theoretically, it should be fine to set the default to `false`, as it appears `isEvalSupported` is only used for performance gains, but to be 100% sure that existing code doesn't break, this PR maintains the current behaviour. Feel free to change this.