### PR TITLE
Specify return type with Function Overloads

### DIFF
--- a/pdf-img-convert.d.ts
+++ b/pdf-img-convert.d.ts
@@ -1,17 +1,31 @@
+type ConversionConfig = {
+    /** Width of the output image in pixels */
+    width?: number;
+    /** Height of the output image in pixels */
+    height?: number;
+    /** A list of page numbers to render (default is all pages) */
+    page_numbers?: number[];
+    /** Whether to output the image in base64 format */
+    base64?: boolean;
+    /** Scaling ratio for the PDF page viewport */
+    scale?: number;
+};
+
+type PDFData = string | Uint8Array | Buffer;
+
 declare function convert(
-    pdf: string | Uint8Array | Buffer,
-    conversion_config?: {
-            /** Width of the output image in pixels */
-            width?: number;
-            /** Height of the output image in pixels */
-            height?: number;
-            /** A list of page numbers to render (default is all pages) */
-            page_numbers?: number[];
-            /** Whether to output the image in base64 format */
-            base64?: boolean;
-            /** Scaling ratio for the PDF page viewport */
-            scale?: number;
-    }
+    pdf: PDFData, 
+    conversion_config: {base64: true} & ConversionConfig
+): Promise<string[]>;
+
+declare function convert(
+    pdf: PDFData, 
+    conversion_config?: {base64?: false} & ConversionConfig
+): Promise<Uint8Array[]>;
+
+declare function convert(
+    pdf: PDFData,
+    conversion_config?: ConversionConfig
 ): Promise<string[] | Uint8Array[]>;
 
 export {convert};


### PR DESCRIPTION
When `pdf2img` is provided with a `conversion_config` where the `base64` property is set to `true`, it returns a `string[]`. Unfortunately, this wasn't reflected in the TypeScript types, so the return type was always a [union](https://typescript.tv/glossary/#union-types) of `string[] | Uint8Array[]`.

![image](https://github.com/user-attachments/assets/67db96d5-6120-45ea-9acc-afc21b65cf39)

## Solution

To correct this type resolution behavior, I improved the `.d.ts` file by utilizing a [Function Overload](https://typescript.tv/glossary/#function-overloading). Now, when `base64` is set to `true`, the `convert` function resolves to a `string[]`. Otherwise, it returns a `Uint8Array[]`.